### PR TITLE
Add assignment operator support for GPIO

### DIFF
--- a/firmware/drivers/include/gpio.hpp
+++ b/firmware/drivers/include/gpio.hpp
@@ -95,6 +95,33 @@ class Gpio {
 		return _port->IDR & (0b1 << _pin);
 	}
 
+	Gpio& operator=(bool on) {
+		Write(on);
+		return *this;
+	}
+
+	Gpio& operator=(int on) {
+		Write(on == 1 ? true : false);
+		return *this;
+	}
+
+	Gpio& operator=(Gpio& other) {
+		// Prevent self-assigment
+		if (this == &other) {
+			return *this;
+		}
+		Write(other.Read());
+		return *this;
+	}
+
+	bool operator==(bool on) {
+		return Read() == on;
+	}
+
+	operator bool() {
+		return Read();
+	}
+
 	Gpio(
 	    GPIO_TypeDef* const port,
 	    uint32_t            pin,


### PR DESCRIPTION
Add support to the GPIO drivers to allow doing the following:
```
Gpio pin(PORT_A, PIN_1);

pin = 1;
pin = 0;
pin = false;
pin = true;
bool pinStatus = pin;

Gpio pin2(PORT_A, PIN_2);
pin2 = pin;
```

Closes #2